### PR TITLE
'str' and 'int' comparison for ansible_version [fixes #1]

### DIFF
--- a/tasks/install-pkgs.yml
+++ b/tasks/install-pkgs.yml
@@ -4,7 +4,7 @@
   package:
     name: "{{ freeipa_client_pkgs }}"
     state: present
-    update_cache: "{{ omit if ((ansible_pkg_mgr == 'dnf') and (ansible_version is version('2.7', '<'))) else 'yes' }}"
+    update_cache: "{{ omit if ((ansible_pkg_mgr == 'dnf') and (ansible_version.full is version('2.7', '<'))) else 'yes' }}"
   delay: 10
   register: result
   retries: 3


### PR DESCRIPTION
Since `ansible_version` returns: `{'string': '2.9.9', 'full': '2.9.9', 'major': 2, 'minor': 9, 'revision': 9}`, `ansible_version.full` fixes the problem.

References:

- https://github.com/ansible/ansible/issues/69975#issuecomment-641660480
- https://www.jeffgeerling.com/blog/2018/require-minimum-ansible-version-your-playbook 